### PR TITLE
Update grub.cfg

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -86,7 +86,7 @@ fi
 # platform, most systems use vga text as primary and ttyS0 as secondary.
 if [ -z "$linux_console" ]; then
     if [ "$grub_platform" = pc ]; then
-        set linux_console="console=ttyS0,115200n8 console=tty0"
+        set linux_console="console=ttyS0,115200n8 console=tty0 nvme_core.io_timeout=4294967295 nvme_core.max_retries=10"
         serial com0 --speed=115200 --word=8 --parity=no
         terminal_input console serial_com0
         terminal_output console serial_com0


### PR DESCRIPTION
updating the grub config to use the nvme defaults required by aws. Should solve the failure to pass status checks. (eventually)
https://github.com/coreos/bugs/issues
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html#timeout-nvme-ebs-volumes